### PR TITLE
IONOS Case Study

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
+# Hello
+
+Hello, thank you for the case study. This task was enjoyable. See you.
+
+### Done's
+
+a370a22 Fix netcat installation for python:3.10 Docker image
+41a9e12 Add happy-path test for the Acceptance Criteria before implementing it
+8a866d0 Add TestFilePathCreateSerializer to validate POST body
+94e14a8 Add  endpoint and TestFilePathCreateAPIView to pass happy-path testing for the AC
+dbeb4b0 Export  from  endpoint to adapt FE Upload dir select component
+649a642 Refactor: Put file upload biz. logic to the  file.
+3dc14e5 Update tests for recent changes in usecases.py
+ef4d9e0 Add more test cases :(unhappy-path):
+d65b4ee Add validation to pass unhappy path test
+aa63f38 Fix N+1 problems in TestRunRequestAPIView and TestRunRequestItemAPIView with select_related and prefetch_related
+268b3d7 Add update_fields argument on each .save() call to prevent all of the model fields from being updated in the database.
+641af65 (HEAD -> oguz/ionos-case-study) Bugfix: Fix the possible race condition by using select_for_update in a transaction block
+
+### Todo's
+#### FE: 
+- In the FE, I detected an issue. When the user upload a test file, the new `TestFilePath` will not be shown in New request section(last input).
+User have to hard refresh their browser tab, to see the recently uploaded file in the select dropdown.
+What could be done:
+In `IONOSTestExecutor` component, `/asset` endpoint called just one time in `componentDidMount`.
+After uploading the file(in the Upload test secion), we can request `/asset` enpoint. 
+
+#### BE:
+
+- In `TestTestFilePathCreateAPIView.test_post_valid_test_file_path`, test uploads a test to the directory. After test execution it can be deleted.
+- The race condition issue could be reproduced in test level by using threads, but I am not sure about to do it in the unit tests.
+
+
+-------------
+
+
 # DCM Technical Task
 
 This is a web application that provides a central place to run Python-based

--- a/api/models.py
+++ b/api/models.py
@@ -39,13 +39,13 @@ class TestEnvironment(Timestampable):
         if self.is_busy():
             raise RuntimeError(f'Trying to lock a busy env(id: {self.id})')
         self.status = TestEnvironment.StatusChoices.BUSY.name
-        self.save()
+        self.save(update_fields=['status'])
 
     def unlock(self):
         if self.is_idle():
             raise RuntimeError(f'Trying to unlock an idle env(id: {self.id})')
         self.status = TestEnvironment.StatusChoices.IDLE.name
-        self.save()
+        self.save(update_fields=['status'])
 
 
 class TestRunRequest(Timestampable):
@@ -68,28 +68,27 @@ class TestRunRequest(Timestampable):
 
     def mark_as_running(self):
         self.status = TestRunRequest.StatusChoices.RUNNING.name
-        self.save()
+        self.save(update_fields=['status'])
+
 
     def mark_as_success(self):
         self.status = TestRunRequest.StatusChoices.SUCCESS.name
-        self.save()
+        self.save(update_fields=['status'])
 
     def mark_as_failed(self):
         self.status = TestRunRequest.StatusChoices.FAILED.name
-        self.save()
+        self.save(update_fields=['status'])
 
     def mark_as_retrying(self):
         self.status = TestRunRequest.StatusChoices.RETRYING.name
-        self.save()
+        self.save(update_fields=['status'])
 
     def mark_as_failed_to_start(self):
         self.status = TestRunRequest.StatusChoices.FAILED_TO_START.name
-        self.save()
+        self.save(update_fields=['status'])
 
     def save_logs(self, logs=None):
         if not logs:
             return
         self.logs += '\n' + logs
-        self.save()
-
-
+        self.save(update_fields=['logs'])

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework import serializers
 
 from api.models import TestRunRequest, TestFilePath, TestEnvironment
@@ -56,7 +57,14 @@ class TestFilePathCreateSerializer(TestFilePathSerializer):
     test_file = serializers.FileField(write_only=True, required=True)
 
     def validate(self, data):
+        upload_dir = data.get('upload_dir')
         test_file = data.get('test_file')
+
+        valid_dirs = settings.TEST_DIRS_WITHOUT_BASE_DIR
+        if upload_dir not in valid_dirs:
+            raise serializers.ValidationError(
+                f'upload_dir should be one of the valid directories: {valid_dirs}'
+            )
 
         if not test_file.name.endswith('.py'):
             raise serializers.ValidationError('test_file must be a python file!')

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -49,6 +49,27 @@ class TestFilePathSerializer(serializers.ModelSerializer):
         fields = ('id', 'path')
 
 
+
+class TestFilePathCreateSerializer(TestFilePathSerializer):
+    """ Extended TestFilePathSerializer for creating a new TestFilePath instance """
+    upload_dir = serializers.CharField(write_only=True, required=True)
+    test_file = serializers.FileField(write_only=True, required=True)
+
+    def validate(self, data):
+        test_file = data.get('test_file')
+
+        if not test_file.name.endswith('.py'):
+            raise serializers.ValidationError('test_file must be a python file!')
+
+        return data
+    
+    class Meta(TestFilePathSerializer.Meta):
+        fields = TestFilePathSerializer.Meta.fields + ('upload_dir', 'test_file')
+        read_only_fields = (
+            'id',
+            'path'
+        )
+
 class TestEnvironmentSerializer(serializers.ModelSerializer):
     class Meta:
         model = TestEnvironment

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -2,6 +2,7 @@ import logging
 import subprocess
 
 from celery import shared_task
+from django.db import transaction
 from django.conf import settings
 
 from api.models import TestRunRequest, TestEnvironment
@@ -30,25 +31,41 @@ def handle_task_retry(instance: TestRunRequest, retry: int) -> None:
 def execute_test_run_request(instance_id: int, retry: int = 0) -> None:
     instance = TestRunRequest.objects.get(id=instance_id)
 
-    if instance.env.is_busy():
-        handle_task_retry(instance, retry)
-        return
+    with transaction.atomic():
+        # use transaction block to ensure that the env is locked and selected for update to prevent race conditions
+        env = TestEnvironment.objects.select_for_update().get(name=instance.env.name)
+        if env.is_busy():
+            handle_task_retry(instance, retry)
+            return 
 
-    env = TestEnvironment.objects.get(name=instance.env.name)
-    env.lock()
+        env.lock()
 
-    cmd = instance.get_command()
-    logger.info(f'Running tests(ID:{instance_id}), CMD({" ".join(cmd)}) on env {instance.env.name}')
+    try:
+        cmd: list = instance.get_command()
+        logger.info(f'Running tests(ID:{instance_id}), CMD({" ".join(cmd)}) on env {instance.env.name}')
+        instance.mark_as_running()
+        
+        run = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        return_code = run.wait(timeout=settings.TEST_RUN_REQUEST_TIMEOUT_SECONDS)
 
-    instance.mark_as_running()
-
-    run = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-    return_code = run.wait(timeout=settings.TEST_RUN_REQUEST_TIMEOUT_SECONDS)
-
-    env.unlock()
-    instance.save_logs(logs=run.stdout.read())
-    if return_code == 0:
-        instance.mark_as_success()
-    else:
+        instance.save_logs(logs=run.stdout.read())
+        if return_code == 0:
+            instance.mark_as_success()
+        else:
+            instance.mark_as_failed()
+        
+        logger.info(f'tests(ID:{instance_id}), CMD({" ".join(cmd)}) on env {instance.env.name} Completed successfully.')
+    
+    except subprocess.TimeoutExpired:
+        logger.error(f'Timeout occurred while running tests(ID:{instance_id}) on env {instance.env.name}')
+        instance.save_logs(logs=f'Timeout occurred while running tests on env {instance.env.name}')
         instance.mark_as_failed()
-    logger.info(f'tests(ID:{instance_id}), CMD({" ".join(cmd)}) on env {instance.env.name} Completed successfully.')
+    
+    except Exception as e:
+        logger.error(f'Error occurred while running tests(ID:{instance_id}) on env {instance.env.name}: {e}')
+        instance.save_logs(logs=f'Error occurred while running tests on env {instance.env.name}: {e}')
+        instance.mark_as_failed()
+    
+    finally:
+        env.unlock()
+

--- a/api/tests/test_usecases.py
+++ b/api/tests/test_usecases.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+from django.conf import settings
 from django.test import TestCase
 
 from api.models import TestFilePath, TestEnvironment
@@ -13,7 +14,11 @@ class TestGetAssets(TestCase):
 
     def test_empty_models(self):
         self.assertEqual(
-            {'available_paths': [], 'test_envs': []},
+            {
+                'available_paths': [],
+                'test_envs': [],
+                'upload_dirs': settings.TEST_DIRS_WITHOUT_BASE_DIR,
+            },
             get_assets()
         )
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -177,5 +177,5 @@ class TestTestFilePathCreateAPIView(TestCase):
         response_data = response.json()
         self.assertIn('id', response_data)
         self.assertIn('path', response_data)
-        self.assertEqual('/sample-tests/my_uploaded_test.py', response_data['path'])
-        self.assertEqual(1, TestFilePath.objects.filter(path='/sample-tests/my_uploaded_test.py').count())
+        self.assertEqual('sample-tests/my_uploaded_test.py', response_data['path'])
+        self.assertEqual(1, TestFilePath.objects.filter(path='sample-tests/my_uploaded_test.py').count())

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -232,5 +232,7 @@ class TestTestFilePathCreateAPIView(TestCase):
         response_data = response.json()
         self.assertIn('id', response_data)
         self.assertIn('path', response_data)
-        self.assertEqual('sample-tests/my_uploaded_test.py', response_data['path'])
-        self.assertEqual(1, TestFilePath.objects.filter(path='sample-tests/my_uploaded_test.py').count())
+
+        self.assertIn('sample-tests/my_uploaded_test', response_data['path'])
+        self.assertTrue(TestFilePath.objects.filter(path__icontains='sample-tests/my_uploaded_test').exists())
+        # Todo: delete 'my_uploaded_test.py' after the test run successfully, 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -155,9 +155,13 @@ class TestAssetsAPIView(TestCase):
         self.assertEqual({'k': 'v'}, response.json())
 
 class TestTestFilePathCreateAPIView(TestCase):
+
+
+    def setUp(self):
+        self.url = reverse('test_file')
     
     def test_post_valid_test_file_path(self):
-        response = self.client.post('/api/v1/test_file', data={
+        response = self.client.post(self.url, data={
             'test_file': SimpleUploadedFile(
                 'my_uploaded_test.py',
                 b'''

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,9 +1,15 @@
 from django.urls import path
 
-from .views import TestRunRequestAPIView, TestRunRequestItemAPIView, AssetsAPIView
+from .views import (
+  TestRunRequestAPIView,
+  TestRunRequestItemAPIView,
+  AssetsAPIView,
+  TestFilePathCreateAPIView,
+)
 
 urlpatterns = [
     path('assets', AssetsAPIView.as_view(), name='assets'),
     path('test-run', TestRunRequestAPIView.as_view(), name='test_run_req'),
     path('test-run/<pk>', TestRunRequestItemAPIView.as_view(), name='test_run_req_item'),
+    path('test-file', TestFilePathCreateAPIView.as_view(), name='test_file')
 ]

--- a/api/usecases.py
+++ b/api/usecases.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.core.files.storage import default_storage
+from django.core.files.base import ContentFile
 
 from api.models import TestFilePath, TestEnvironment
 from api.serializers import TestFilePathSerializer, TestEnvironmentSerializer
@@ -12,3 +14,13 @@ def get_assets():
         # or it can be done like this if the source of truth is the database, but it's not the case here
         # 'upload_dirs': {path.split('/')[0] for path in TestFilePath.objects.values_list('path', flat=True)},
     }
+
+
+def upload_test_file_path(serializer) -> str:
+    """ Uploads test file to the specified directory and returns the path """
+    upload_dir = serializer.validated_data.pop('upload_dir')
+    test_file_object = serializer.validated_data.pop('test_file')
+    
+    path = f'{upload_dir}/{test_file_object.name}'
+
+    return default_storage.save(f'{settings.BASE_DIR}{path}', ContentFile(test_file_object.read()))

--- a/api/usecases.py
+++ b/api/usecases.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from api.models import TestFilePath, TestEnvironment
 from api.serializers import TestFilePathSerializer, TestEnvironmentSerializer
 
@@ -5,5 +7,8 @@ from api.serializers import TestFilePathSerializer, TestEnvironmentSerializer
 def get_assets():
     return {
         'available_paths': TestFilePathSerializer(TestFilePath.objects.all().order_by('path'), many=True).data,
-        'test_envs': TestEnvironmentSerializer(TestEnvironment.objects.all().order_by('name'), many=True).data
+        'test_envs': TestEnvironmentSerializer(TestEnvironment.objects.all().order_by('name'), many=True).data,
+        'upload_dirs': settings.TEST_DIRS_WITHOUT_BASE_DIR,
+        # or it can be done like this if the source of truth is the database, but it's not the case here
+        # 'upload_dirs': {path.split('/')[0] for path in TestFilePath.objects.values_list('path', flat=True)},
     }

--- a/api/views.py
+++ b/api/views.py
@@ -1,7 +1,3 @@
-from django.conf import settings
-from django.core.files.storage import default_storage
-from django.core.files.base import ContentFile
-
 from rest_framework import status, parsers
 from rest_framework.generics import CreateAPIView, ListCreateAPIView, RetrieveAPIView
 from rest_framework.response import Response
@@ -14,7 +10,7 @@ from api.serializers import (
   TestFilePathCreateSerializer
 )
 from api.tasks import execute_test_run_request
-from api.usecases import get_assets
+from api.usecases import get_assets, upload_test_file_path
 
 
 class TestRunRequestAPIView(ListCreateAPIView):
@@ -39,12 +35,7 @@ class TestFilePathCreateAPIView(CreateAPIView):
     
 
     def perform_create(self, serializer):
-        upload_dir = serializer.validated_data.pop('upload_dir')
-        test_file_object = serializer.validated_data.pop('test_file')
-        
-        path = f'{upload_dir}/{test_file_object.name}'
-
-        default_storage.save(f'{settings.BASE_DIR}{path}', ContentFile(test_file_object.read()))
+        path: str = upload_test_file_path(serializer)
         serializer.validated_data['path'] = path
         serializer.save()
 

--- a/api/views.py
+++ b/api/views.py
@@ -1,10 +1,18 @@
-from rest_framework import status
-from rest_framework.generics import ListCreateAPIView, RetrieveAPIView
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.core.files.base import ContentFile
+
+from rest_framework import status, parsers
+from rest_framework.generics import CreateAPIView, ListCreateAPIView, RetrieveAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from api.models import TestRunRequest
-from api.serializers import TestRunRequestSerializer, TestRunRequestItemSerializer
+from api.models import TestRunRequest, TestFilePath
+from api.serializers import (
+  TestRunRequestSerializer,
+  TestRunRequestItemSerializer,
+  TestFilePathCreateSerializer
+)
 from api.tasks import execute_test_run_request
 from api.usecases import get_assets
 
@@ -22,6 +30,23 @@ class TestRunRequestItemAPIView(RetrieveAPIView):
     serializer_class = TestRunRequestItemSerializer
     queryset = TestRunRequest.objects.all()
     lookup_field = 'pk'
+
+
+class TestFilePathCreateAPIView(CreateAPIView):
+    serializer_class = TestFilePathCreateSerializer
+    queryset = TestFilePath.objects.all()
+    parser_classes = [parsers.JSONParser, parsers.MultiPartParser]
+    
+
+    def perform_create(self, serializer):
+        upload_dir = serializer.validated_data.pop('upload_dir')
+        test_file_object = serializer.validated_data.pop('test_file')
+        
+        path = f'{upload_dir}/{test_file_object.name}'
+
+        default_storage.save(f'{settings.BASE_DIR}{path}', ContentFile(test_file_object.read()))
+        serializer.validated_data['path'] = path
+        serializer.save()
 
 
 class AssetsAPIView(APIView):

--- a/api/views.py
+++ b/api/views.py
@@ -15,7 +15,13 @@ from api.usecases import get_assets, upload_test_file_path
 
 class TestRunRequestAPIView(ListCreateAPIView):
     serializer_class = TestRunRequestSerializer
-    queryset = TestRunRequest.objects.all().order_by('-created_at')
+    queryset = TestRunRequest.objects.select_related(
+        'env'
+    ).prefetch_related(
+        'path'
+    ).order_by(
+        '-created_at'
+    )
 
     def perform_create(self, serializer):
         instance = serializer.save()
@@ -24,7 +30,7 @@ class TestRunRequestAPIView(ListCreateAPIView):
 
 class TestRunRequestItemAPIView(RetrieveAPIView):
     serializer_class = TestRunRequestItemSerializer
-    queryset = TestRunRequest.objects.all()
+    queryset = TestRunRequest.objects.select_related('env').prefetch_related('path')
     lookup_field = 'pk'
 
 

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -3,7 +3,7 @@ FROM python:3.10
 WORKDIR /code
 
 RUN apt-get -y update \
-    && apt-get install -y python3-dev libpq-dev postgresql postgresql-contrib netcat \
+    && apt-get install -y python3-dev libpq-dev postgresql postgresql-contrib netcat-traditional \
     && apt-get -y clean
 
 RUN pip install --upgrade poetry

--- a/ionos/settings.py
+++ b/ionos/settings.py
@@ -147,7 +147,7 @@ TEST_BASE_DIRS = [
     os.path.join(BASE_DIR, 'sample-tests'),
     os.path.join(BASE_DIR, 'api/tests'),
 ]
-TEST_DIRS_WITHOUT_BASE_DIR = [directory[len(BASE_DIR)+1:] for directory in TEST_BASE_DIRS]
+TEST_DIRS_WITHOUT_BASE_DIR = [directory[len(BASE_DIR):] for directory in TEST_BASE_DIRS]
 TEST_RUN_REQUEST_TIMEOUT_SECONDS = 60 * 60 * 30  # 30 Minutes
 TEST_BASE_CMD = ['pytest', '-v']
 

--- a/ionos/settings.py
+++ b/ionos/settings.py
@@ -147,6 +147,7 @@ TEST_BASE_DIRS = [
     os.path.join(BASE_DIR, 'sample-tests'),
     os.path.join(BASE_DIR, 'api/tests'),
 ]
+TEST_DIRS_WITHOUT_BASE_DIR = [directory[len(BASE_DIR)+1:] for directory in TEST_BASE_DIRS]
 TEST_RUN_REQUEST_TIMEOUT_SECONDS = 60 * 60 * 30  # 30 Minutes
 TEST_BASE_CMD = ['pytest', '-v']
 

--- a/sample-tests/my_uploaded_test.py
+++ b/sample-tests/my_uploaded_test.py
@@ -1,0 +1,6 @@
+
+                    from django.test import TestCase
+                    class TestSuccess(TestCase):
+                        def test_1(self):
+                            pass
+                

--- a/sample-tests/my_uploaded_test.py
+++ b/sample-tests/my_uploaded_test.py
@@ -1,6 +1,0 @@
-
-                    from django.test import TestCase
-                    class TestSuccess(TestCase):
-                        def test_1(self):
-                            pass
-                


### PR DESCRIPTION
# Hello

Hello, thank you for the case study. This task was enjoyable. See you.

### Done's

a370a22 Fix netcat installation for python:3.10 Docker image
41a9e12 Add happy-path test for the Acceptance Criteria before implementing it
8a866d0 Add TestFilePathCreateSerializer to validate POST body
94e14a8 Add  endpoint and TestFilePathCreateAPIView to pass happy-path testing for the AC
dbeb4b0 Export  from  endpoint to adapt FE Upload dir select component
649a642 Refactor: Put file upload biz. logic to the  file.
3dc14e5 Update tests for recent changes in usecases.py
ef4d9e0 Add more test cases :(unhappy-path):
d65b4ee Add validation to pass unhappy path test
aa63f38 Fix N+1 problems in TestRunRequestAPIView and TestRunRequestItemAPIView with select_related and prefetch_related
268b3d7 Add update_fields argument on each .save() call to prevent all of the model fields from being updated in the database.
641af65 (HEAD -> oguz/ionos-case-study) Bugfix: Fix the possible race condition by using select_for_update in a transaction block

### Todo's
#### FE: 
- In the FE, I detected an issue. When the user upload a test file, the new `TestFilePath` will not be shown in New request section(last input).
User have to hard refresh their browser tab, to see the recently uploaded file in the select dropdown.
What could be done:
In `IONOSTestExecutor` component, `/asset` endpoint called just one time in `componentDidMount`.
After uploading the file(in the Upload test secion), we can request `/asset` enpoint. 

#### BE:

- In `TestTestFilePathCreateAPIView.test_post_valid_test_file_path`, test uploads a test to the directory. After test execution it can be deleted.
- The race condition issue could be reproduced in test level by using threads, but I am not sure about to do it in the unit tests.

